### PR TITLE
Convert Task Event Dates to Moments resolves #8

### DIFF
--- a/tests/unit/ActivityView.spec.js
+++ b/tests/unit/ActivityView.spec.js
@@ -39,8 +39,14 @@ const shouldBehaveLikeActivityView = function (wrapper) {
     expect(wrapper.vm.view).toBe('daily')
     
     const activityLogs = wrapper.findAll(Activity)
-    expect(activityLogs.at(0).props()).toEqual({ activity: activity.slice(0, 3), day: moment(completedDate).subtract(1, 'd').format(EXPECTED_DAY_KEY_FORMAT) })
-    expect(activityLogs.at(1).props()).toEqual({ activity: activity.slice(3, 6), day: moment(completedDate).format(EXPECTED_DAY_KEY_FORMAT) })
+    expect(activityLogs.at(0).props()).toEqual({
+      activity: activity.slice(0, 3),
+      day: moment(completedDate).subtract(1, 'd').format(EXPECTED_DAY_KEY_FORMAT)
+    })
+    expect(activityLogs.at(1).props()).toEqual({
+      activity: activity.slice(3, 6),
+      day: completedDate.format(EXPECTED_DAY_KEY_FORMAT)
+    })
     
   })
   

--- a/tests/unit/fixtures.js
+++ b/tests/unit/fixtures.js
@@ -3,14 +3,13 @@ import moment from 'moment'
 
 export function generateActivity () {
   
-  const completedDate = new Date()
-  completedDate.setHours(12)
+  const completedDate = moment()
   
   return {
     activity: [
       {
         type: eventTypes.Created,
-        time: moment(completedDate).subtract(1, 'd')
+        time: moment(completedDate).subtract(1, 'd').valueOf()
       },
       {
         type: eventTypes.Started,
@@ -30,7 +29,7 @@ export function generateActivity () {
       },
       {
         type: eventTypes.Completed,
-        time: completedDate
+        time: completedDate.valueOf()
       }
     ],
     completedDate
@@ -46,7 +45,7 @@ export function newTask (includeTags = false) {
     name: 'new task 1',
     activity: [{
       type: eventTypes.Created,
-      time: Date.now()
+      time: moment.now()
     }],
     tags,
     completed: false


### PR DESCRIPTION
using moments everywhere requires more import statements, adds no value